### PR TITLE
Fix crash when challenge mode is disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,24 @@
 /cmake-build-*/
 /.idea/
+
+# Ignore all temporary files created by text editors
+*.swp
+*.tmp
+
+
+# Ignore local configuration files
+*.env
+*.local
+
+# Ignore backup files
+*.bak
+*.orig
+
+# Ignore build folders
+/out/
+/dist/
+
+# Ignore Visual Studio IDE files
+.vscode/
+.vs/
+

--- a/src/bosses/data.cpp
+++ b/src/bosses/data.cpp
@@ -113,7 +113,6 @@ void BossDataSet::saveConfig() const {
 }
 
 void BossDataSet::initMemoryAddresses() {
-    if (challengeMode_)
     {
         Signature sig("48 8B 05 ?? ?? ?? ?? 48 85 C0 74 05 48 8B 40 58 C3 C3");
         auto res = sig.scan();


### PR DESCRIPTION
gameDataMan_ is used on update loop even if  challengeMode_ is set to false.
It makes the game crash