### PR TITLE
Fix crash when challenge mode is disabled

### DIFF
--- a/src/bosses/data.cpp
+++ b/src/bosses/data.cpp
@@ -113,7 +113,6 @@ void BossDataSet::saveConfig() const {
 }
 
 void BossDataSet::initMemoryAddresses() {
-    if (challengeMode_)
     {
         Signature sig("48 8B 05 ?? ?? ?? ?? 48 85 C0 74 05 48 8B 40 58 C3 C3");
         auto res = sig.scan();


### PR DESCRIPTION
gameDataMan_ is used on the update loop even when challengeMode_ is off.
It makes the game crash