### PR TITLE
Fix igt 24h rounding issue

### DIFF
--- a/src/boss/render.cpp
+++ b/src/boss/render.cpp
@@ -193,4 +193,17 @@ bool Renderer::render() {
     return showFull_;
 }
 
+std::string Renderer::format_time() const {
+    using namespace std::chrono;
+
+    const auto total_seconds = duration_cast<seconds>(igt_).count();
+    auto hours   = total_seconds / 3600;
+    auto minutes = (total_seconds / 60) % 60;
+    auto seconds = total_seconds % 60;
+
+    if (hours > 0) {
+        return fmt::format("{:02}:{:02}:{:02}", hours, minutes, seconds);
+    }
+    return fmt::format("{:02}:{:02}", minutes, seconds);
+}
 }

--- a/src/boss/render.cpp
+++ b/src/boss/render.cpp
@@ -28,17 +28,11 @@ void Renderer::init(void *context, void *allocFunc, void *freeFunc, void *userDa
     const std::string from = "$n";
     const std::string to = "\n";
     const std::string from2 = "{igt}";
-    const std::string to2 = "{igt:.0%M:%S}";
-    const std::string from3 = "{igt}";
-    const std::string to3 = "{igt:.0%H:%M:%S}";
+    const std::string to2 = "$igt";
     util::replaceAll(killText_, from, to);
     util::replaceAll(challengeText_, from, to);
-    killTextHour_ = killText_;
-    challengeTextHour_ = challengeText_;
     util::replaceAll(killText_, from2, to2);
     util::replaceAll(challengeText_, from2, to2);
-    util::replaceAll(killTextHour_, from3, to3);
-    util::replaceAll(challengeTextHour_, from3, to3);
     allowRevive_ = api->configEnabled("boss.allow_revive");
     const auto &pos = api->configGet("boss.panel_pos");
     auto posVec = util::strSplitToFloatVec(pos);
@@ -54,7 +48,6 @@ void Renderer::init(void *context, void *allocFunc, void *freeFunc, void *userDa
     args_.push_back(fmt::arg("deaths", std::cref(deaths_)));
     args_.push_back(fmt::arg("pb", std::cref(pb_)));
     args_.push_back(fmt::arg("tries", std::cref(tries_)));
-    args_.push_back(fmt::arg("igt", std::cref(igt_)));
 }
 
 inline static float calculatePos(float w, float n) {
@@ -99,10 +92,12 @@ bool Renderer::render() {
                          ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings))
         {
             if (challengeMode) {
-                auto text = fmt::vformat(igt < 3600000 ? challengeText_ : challengeTextHour_, args_);
+                auto text = fmt::vformat(challengeText_, args_);
+                util::replaceAll(text, std::string("$igt"), format_time());
                 ImGui::TextUnformatted(text.c_str());
             } else {
-                auto text = fmt::vformat(igt < 3600000 ? killText_ : killTextHour_, args_);
+                auto text = fmt::vformat(killText_, args_);
+                util::replaceAll(text, std::string("$igt"), format_time());
                 ImGui::TextUnformatted(text.c_str());
             }
             ImGui::SameLine();
@@ -122,10 +117,12 @@ bool Renderer::render() {
                 regionIndex = -1;
             }
             if (gBossDataSet.challengeMode()) {
-                auto text = fmt::vformat(igt < 3600000 ? challengeText_ : challengeTextHour_, args_);
+                auto text = fmt::vformat(challengeText_, args_);
+                util::replaceAll(text, std::string("$igt"), format_time());
                 ImGui::TextUnformatted(text.c_str());
             } else {
-                auto text = fmt::vformat(igt < 3600000 ? killText_ : killTextHour_, args_);
+                auto text = fmt::vformat(killText_, args_);
+                util::replaceAll(text, std::string("$igt"), format_time());
                 ImGui::TextUnformatted(text.c_str());
             }
             auto &style = ImGui::GetStyle();
@@ -197,7 +194,7 @@ std::string Renderer::format_time() const {
     using namespace std::chrono;
 
     const auto total_seconds = duration_cast<seconds>(igt_).count();
-    auto hours   = total_seconds / 3600;
+    auto hours = total_seconds / 3600;
     auto minutes = (total_seconds / 60) % 60;
     auto seconds = total_seconds % 60;
 

--- a/src/boss/render.hpp
+++ b/src/boss/render.hpp
@@ -21,6 +21,7 @@ class Renderer {
 public:
     void init(void *context, void *allocFunc, void *freeFunc, void *userData);
     bool render();
+    std::string format_time() const;
 
 private:
     bool showFull_ = false;

--- a/src/boss/render.hpp
+++ b/src/boss/render.hpp
@@ -34,8 +34,8 @@ private:
     float height_ = 0.9f;
 
     /* dynamic format args */
-    std::string killText_, killTextHour_;
-    std::string challengeText_, challengeTextHour_;
+    std::string killText_;
+    std::string challengeText_;
     fmt::dynamic_format_arg_store<fmt::format_context> args_;
 
     std::chrono::milliseconds igt_;


### PR DESCRIPTION
Fixed issue when igt was rounding to 24h because of the `"{igt:.0%H:%M:%S}"` pattern

Fixed IGT vs original IGT % 24 (208 % 24 = 16)
<img width="244" height="244" alt="image" src="https://github.com/user-attachments/assets/f6a4991f-0eb0-4092-8f0f-23e4cebc8503" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined time display formatting by consolidating duplicate time format variants into a unified formatting system, improving code maintainability.
  * Time values are now consistently formatted using a single standardized method, replacing multiple format variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->